### PR TITLE
Change the CMMGR variable to point to a /tmp directory

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   run_exports:
     - {{ pin_subpackage("cm", max_pin="x") }}
-  number: 1
+  number: 2
   skip: True  # [win or osx]
 
 requirements:

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 # Store existing env vars so we can restore them later
-if [ -z "$CMDOMAIN" ]; then
+if [ ! -z "$CMDOMAIN" ]; then
     export _CONDA_SET_CMDOMAIN=$CMDOMAIN
 fi
 export CMDOMAIN=Conda
 
-if [ -z "$CMMGR" ]; then
+if [ ! -z "$CMMGR" ]; then
     export _CONDA_SET_CMMGR=$CMMGR
 fi
 
 # Check if varible CMTMPDIR exist, otherwise checks if TMPDIR varible is set and if not sets it to /tmp
-if [ -z "$CMTMPDIR" ]; then
+if [ ! -z "$CMTMPDIR" ]; then
     TMPDIR=$CMTMPDIR
 elif [ -z "$TMPDIR" ]; then
     TMPDIR=/tmp
@@ -20,7 +20,7 @@ mkdir -p $TMPDIR/cm/mgr
 export CMMGR=$TMPDIR/cm/mgr
 
 #Create the cmdomains file if it does not already exist
-CMDOMAINS=$TMPDIR/cm/mgr/CmDomains
+CMDOMAINS=$CONDA_PREFIX/share/cm/mgr/CmDomains
 if [ ! -f "$CMDOMAINS" ]; then 
-    echo "Conda localhost  19000 19001 899 $TMPDIR/cm" > $TMPDIR/cm/mgr/CmDomains
+    echo "Conda localhost  19000 19001 899 $TMPDIR/cm" > $CONDA_PREFIX/share/cm/mgr/CmDomains
 fi

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -20,7 +20,7 @@ mkdir -p $TMPDIR/cm/mgr
 export CMMGR=$TMPDIR/cm/mgr
 
 #Create the cmdomains file if it does not already exist
-CMDOMAINS=$CONDA_PREFIX/share/cm/mgr/CmDomains
+CMDOMAINS=$TMPDIR/cm/mgr/CmDomains
 if [ ! -f "$CMDOMAINS" ]; then 
-    echo "Conda localhost  19000 19001 899 $TMPDIR/cm" > $CONDA_PREFIX/share/cm/mgr/CmDomains
+    echo "Conda localhost  19000 19001 899 $TMPDIR/cm" > $TMPDIR/cm/mgr/CmDomains
 fi

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -9,11 +9,18 @@ if [ -z "$CMMGR" ]; then
     export _CONDA_SET_CMMGR=$CMMGR
 fi
 
-mkdir -p $CONDA_PREFIX/share/cm/mgr
-export CMMGR=$CONDA_PREFIX/share/cm/mgr
+# Check if varible CMTMPDIR exist, otherwise checks if TMPDIR varible is set and if not sets it to /tmp
+if [ -z "$CMTMPDIR" ]; then
+    TMPDIR=$CMTMPDIR
+elif [ -z "$TMPDIR" ]; then
+    TMPDIR=/tmp
+fi
+
+mkdir -p $TMPDIR/cm/mgr
+export CMMGR=$TMPDIR/cm/mgr
 
 #Create the cmdomains file if it does not already exist
-CMDOMAINS=$CONDA_PREFIX/share/cm/mgr/CmDomains
+CMDOMAINS=$TMPDIR/cm/mgr/CmDomains
 if [ ! -f "$CMDOMAINS" ]; then 
-    echo "Conda localhost  19000 19001 899 $CONDA_PREFIX/share/cm" > $CONDA_PREFIX/share/cm/mgr/CmDomains
+    echo "Conda localhost  19000 19001 899 $TMPDIR/cm" > $TMPDIR/cm/mgr/CmDomains
 fi

--- a/recipe/scripts/deactivate.sh
+++ b/recipe/scripts/deactivate.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 # Restore previous env vars if any
 export CMDOMAIN=
-if [ -z "$_CONDA_SET_CMDOMAIN" ]; then
+if [ ! -z "$_CONDA_SET_CMDOMAIN" ]; then
     export CMDOMAIN=$_CONDA_SET_CMDOMAIN
     export _CONDA_SET_CMDOMAIN=
 fi
 
 export CMMGR=
-if [ -z "$_CONDA_SET_CMMGR" ]; then
+if [ ! -z "$_CONDA_SET_CMMGR" ]; then
     export CMMGR=$_CONDA_SET_CMMGR
     export _CONDA_SET_CMMGR=
 fi


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This pull request changes the `CMMGR` environmental variable and sets it to `$CMTMPDIR/cm/mgr/` if the `CMTMPDIR` environmental variable exists, otherwise, it will check `TMPDIR` environmental variable exists and set `CMMGR=$TMPDIR/cm/mgr/`. If `TMPDIR` is also not defined then it will default to `/tmp/cm/mgr`. 
