### PR TITLE
Put all Cm data into the /tmp directory

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   run_exports:
     - {{ pin_subpackage("cm", max_pin="x") }}
-  number: 1
+  number: 2
   skip: True  # [win or osx]
 
 requirements:

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -8,12 +8,19 @@ if [ -z "${CMDOMAIN+x}" ]; then
         export _CONDA_SET_CMMGR=$CMMGR
     fi
 
-    mkdir -p $CONDA_PREFIX/share/cm/mgr
-    export CMMGR=$CONDA_PREFIX/share/cm/mgr
+    # Check if varible CMTMPDIR exist, otherwise checks if TMPDIR varible is set and if not sets it to /tmp
+    if [ ! -z "$CMTMPDIR" ]; then
+        TMPDIR=$CMTMPDIR
+    elif [ -z "$TMPDIR" ]; then
+        TMPDIR=/tmp
+    fi
+
+    mkdir -p $TMPDIR/cm/mgr
+    export CMMGR=$TMPDIR/cm/mgr
 
     #Create the cmdomains file if it does not already exist
-    CMDOMAINFILE=$CONDA_PREFIX/share/cm/mgr/CmDomains
-    if [ ! -f "$CMDOMAINFILE" ]; then
-        echo "Conda localhost  19000 19001 899 $CONDA_PREFIX/share/cm" > $CONDA_PREFIX/share/cm/mgr/CmDomains
+    CMDOMAINS=$TMPDIR/cm/mgr/CmDomains
+    if [ ! -f "$CMDOMAINS" ]; then
+        echo "Conda localhost  19000 19001 899 $TMPDIR/cm" > $TMPDIR/cm/mgr/CmDomains
     fi
 fi


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Currently, the `Cm` data is written into `${PREFIX}/share/cm`, but this is not writable meaning that the `Cm` process will run into a `Permission Denied` error. This merge request resolves this by changing the CMMGR, CMDOMAINS environmental variables and data directory in the CmDomains file to use the CMTMPDIR environmental variable if it exists, otherwise, it will use the TMPDIR environmental variable. If, however, TMPDIR is also not defined then it will default to /tmp.
